### PR TITLE
data type mismatch fix to fp32

### DIFF
--- a/export_model.py
+++ b/export_model.py
@@ -32,7 +32,7 @@ class KvCacheStateLlamaForCausalLM(torch.nn.Module):
         self.device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model = LlamaForCausalLM.from_pretrained(
             model_path,
-            torch_dtype=torch.float16,
+            torch_dtype=torch.float32,
             device_map=self.device
         ).eval()
         
@@ -91,7 +91,7 @@ def export_kv_cache_model(
             ct.TensorType(shape=input_shape, dtype=np.int32, name="attentionMask"),
         ]
         
-        outputs = [ct.TensorType(dtype=np.float16, name="logits")]
+        outputs = [ct.TensorType(dtype=np.float32, name="logits")]
         
         mlmodel = ct.convert(
             traced_model,

--- a/llama_implementation.py
+++ b/llama_implementation.py
@@ -74,7 +74,7 @@ def export_baseline_model(
             ct.TensorType(shape=input_shape, dtype=np.int32, name="attentionMask"),
         ]
         
-        outputs = [ct.TensorType(dtype=np.float16, name="logits")]
+        outputs = [ct.TensorType(dtype=np.float32, name="logits")]
         
         mlmodel = ct.convert(
             traced_model,


### PR DESCRIPTION
When running the model, I would get this runtime error:
raise RuntimeError(f"Model conversion failed: {str(e)}") RuntimeError: Model conversion failed: In op, of type mul, named mul_0, the named input `y` must have the same data type as the named input `x`. However, y has dtype fp32 whereas x has dtype fp16.

These changes fixed this error for me